### PR TITLE
travis-ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,50 @@
+sudo: required
+dist: trusty
+
+os: linux
+
+language: c
+
+compiler:
+  - gcc
+  - clang
+
+env:
+  global:
+    - LUAJIT_PREFIX=/opt/luajit21
+    - LUAJIT_LIB=$LUAJIT_PREFIX/lib
+    - LD_LIBRARY_PATH=$LUAJIT_LIB:$LD_LIBRARY_PATH
+    - LUAJIT_INC=$LUAJIT_PREFIX/include/luajit-2.1
+    - LUA_INCLUDE_DIR=$LUAJIT_INC
+    - LUA_CMODULE_DIR=/lib
+    - JOBS=3
+    - NGX_BUILD_JOBS=$JOBS
+    - TEST_NGINX_SLEEP=0.006
+  matrix:
+    - NGINX_VERSION=1.9.15
+
+before_install:
+  - sudo apt-get install -qq -y axel ragel cpanminus libtest-base-perl libtext-diff-perl liburi-perl libwww-perl libtest-longstring-perl liblist-moreutils-perl > build.log 2>&1 || (cat build.log && exit 1)
+
+install:
+  - mkdir ~/git
+  - git clone https://github.com/openresty/nginx-devel-utils.git
+  - git clone https://github.com/openresty/openresty.git ../openresty
+  - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
+  - git clone https://github.com/simpl/ngx_devel_kit.git ~/git/ndk-nginx-module
+  - git clone https://github.com/openresty/test-nginx.git
+  - git clone -b v2.1-agentzh https://github.com/openresty/luajit2.git
+  - git clone https://github.com/openresty/lua-nginx-module.git ~/git/lua-nginx-module
+  - git clone https://github.com/openresty/echo-nginx-module.git ~/git/echo-nginx-module
+
+script:
+  - cd luajit2
+  - make -j$JOBS CCDEBUG=-g Q= PREFIX=$LUAJIT_PREFIX CC=$CC XCFLAGS='-DLUA_USE_APICHECK -DLUA_USE_ASSERT' > build.log 2>&1 || (cat build.log && exit 1)
+  - sudo make install PREFIX=$LUAJIT_PREFIX > build.log 2>&1 || (cat build.log && exit 1)
+  - cd ../test-nginx && sudo cpanm . && cd ..
+  - export PATH=$PWD/work/nginx/sbin:$PWD/nginx-devel-utils:$PATH
+  - export NGX_BUILD_CC=$CC
+  - bash -x util/build.sh $NGINX_VERSION
+  - nginx -V
+  - ldd `which nginx`|grep -E 'luajit|ssl'
+  - prove -r t

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
   - cd ../test-nginx && sudo cpanm . && cd ..
   - export PATH=$PWD/work/nginx/sbin:$PWD/nginx-devel-utils:$PATH
   - export NGX_BUILD_CC=$CC
-  - bash -x util/build.sh $NGINX_VERSION
+  - sh util/build.sh $NGINX_VERSION  > build.log 2>&1 || (cat build.log && exit 1)
   - nginx -V
   - ldd `which nginx`|grep -E 'luajit|ssl'
   - prove -r t


### PR DESCRIPTION
util/build.sh uses slightly different folder naming convention, i.e. modules located at ~/git/module-name instead of ../module-name

should we change that ?